### PR TITLE
fix: make ypi launcher work on macOS bash 3.2

### DIFF
--- a/tests/test_unit.sh
+++ b/tests/test_unit.sh
@@ -359,6 +359,19 @@ AFTER_COUNT=$(ls /tmp/rlm_ctx_d* 2>/dev/null | wc -l || echo 0)
 # For now just verify it created one
 assert_contains "T15: temp context created" "MOCK_PI_CALLED" "$OUTPUT"
 
+# ─── Test Group: ypi Launcher ────────────────────────────────────────────
+
+echo ""
+echo "=== ypi Launcher ==="
+
+# T16: ypi should work with no pass-through args (bash 3.2 + set -u regression)
+OUTPUT=$(
+    CONTEXT="$TEST_TMP/ctx.txt" \
+    "$PROJECT_DIR/ypi"
+)
+assert_contains "T16: ypi launches pi with no args" "MOCK_PI_CALLED" "$OUTPUT"
+assert_contains "T16: ypi forwards --system-prompt" "--system-prompt" "$OUTPUT"
+
 # ─── Summary ──────────────────────────────────────────────────────────────
 
 echo ""

--- a/ypi
+++ b/ypi
@@ -66,7 +66,7 @@ mkdir -p "$RLM_SESSION_DIR"
 
 # Build combined system prompt: SYSTEM_PROMPT.md + rlm_query source
 # This way the agent sees the full implementation, not just usage docs.
-COMBINED_PROMPT=$(mktemp /tmp/ypi_system_prompt_XXXXXX.md)
+COMBINED_PROMPT=$(mktemp "${TMPDIR:-/tmp}/ypi_system_prompt.XXXXXX")
 trap 'rm -f "$COMBINED_PROMPT"' EXIT
 
 cat "$SCRIPT_DIR/SYSTEM_PROMPT.md" > "$COMBINED_PROMPT"
@@ -116,4 +116,13 @@ while [[ $# -gt 0 ]]; do
 done
 # Launch Pi with the combined system prompt, passing all args through
 # User's own extensions (hashline, etc.) are discovered automatically by Pi.
-exec pi --system-prompt "$COMBINED_PROMPT" "${YPI_EXT_ARGS[@]}" "${PASS_ARGS[@]}"
+# Bash 3.2 (macOS) + `set -u` treats `${empty_array[@]}` as unbound.
+# Build argv incrementally so zero-length arrays stay zero-arg.
+PI_ARGS=(pi --system-prompt "$COMBINED_PROMPT")
+if [ ${#YPI_EXT_ARGS[@]} -gt 0 ]; then
+    PI_ARGS+=("${YPI_EXT_ARGS[@]}")
+fi
+if [ ${#PASS_ARGS[@]} -gt 0 ]; then
+    PI_ARGS+=("${PASS_ARGS[@]}")
+fi
+exec "${PI_ARGS[@]}"


### PR DESCRIPTION
## Summary

Fixes macOS startup failures in the `ypi` launcher by addressing two shell-compatibility issues:

1. `set -u` + empty array expansion on Bash 3.2 (`PASS_ARGS[@]: unbound variable`)
2. Non-portable `mktemp` template usage on BSD/macOS

## Changes

- Use portable temp-file template:
  - `mktemp "${TMPDIR:-/tmp}/ypi_system_prompt.XXXXXX"`
- Build `pi` argv incrementally and only append optional arrays when non-empty:
  - avoids `"${empty_array[@]}"` nounset crash on macOS system Bash 3.2
- Add unit regression test in `tests/test_unit.sh`:
  - invokes `ypi` with no pass-through args and asserts it reaches mock `pi`

## Repro verified

On macOS with `/bin/bash` 3.2:

- `ypi` no longer crashes with `PASS_ARGS[@]: unbound variable`
- repeated `ypi` invocations no longer fail with `mktemp ... File exists`

## Related issues

- Fixes #2
- Fixes #1 (launcher `mktemp` portability issue)
