### PR TITLE
fix: sync RLM model/provider into child calls after interactive model switch

### DIFF
--- a/extensions/ypi.ts
+++ b/extensions/ypi.ts
@@ -2,38 +2,57 @@
  * ypi Status Extension
  *
  * Shows that this is ypi (recursive Pi), not vanilla Pi.
- * Displays recursion depth info in the footer status bar
- * and sets the terminal title to "ypi".
+ * Displays recursion depth info in the footer status bar,
+ * sets the terminal title to "ypi", and keeps the subprocess
+ * environment aligned with Pi's live session/model state.
  *
  * Reads configuration from environment variables set by the ypi launcher:
  *   RLM_DEPTH      — current recursion depth (default: 0)
  *   RLM_MAX_DEPTH  — maximum recursion depth (default: 3)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ModelSelectEvent } from "@mariozechner/pi-coding-agent";
+
+function setEnv(name: string, value: string | undefined) {
+	if (value) process.env[name] = value;
+	else delete process.env[name];
+}
+
+function syncRlmEnv(ctx: ExtensionContext, model = ctx.model, options?: { preserveExistingModel?: boolean }) {
+	// Bash tool executions inherit process.env, so keep these values current
+	// when the user switches models or sessions.
+	if (model) {
+		setEnv("RLM_PROVIDER", model.provider);
+		setEnv("RLM_MODEL", model.id);
+	} else if (!options?.preserveExistingModel) {
+		delete process.env.RLM_PROVIDER;
+		delete process.env.RLM_MODEL;
+	}
+	setEnv("RLM_SESSION_FILE", ctx.sessionManager.getSessionFile());
+}
+
+function updateUi(ctx: ExtensionContext, depth: number, maxDepth: number) {
+	const theme = ctx.ui.theme;
+
+	// Footer status: ypi with depth info
+	const label = theme.fg("accent", "ypi");
+	const depthInfo = theme.fg("dim", ` ∞ depth ${depth}/${maxDepth}`);
+	ctx.ui.setStatus("ypi", label + depthInfo);
+
+	// Terminal tab/window title
+	ctx.ui.setTitle("ypi");
+}
 
 export default function (pi: ExtensionAPI) {
 	const depth = parseInt(process.env.RLM_DEPTH || "0", 10);
 	const maxDepth = parseInt(process.env.RLM_MAX_DEPTH || "3", 10);
 
-	pi.on("session_start", async (_event, ctx) => {
-		const theme = ctx.ui.theme;
-
-		// Footer status: ypi with depth info
-		const label = theme.fg("accent", "ypi");
-		const depthInfo = theme.fg("dim", ` ∞ depth ${depth}/${maxDepth}`);
-		ctx.ui.setStatus("ypi", label + depthInfo);
-
-		// Terminal tab/window title
-		ctx.ui.setTitle("ypi");
+	pi.on("session_start", (_event, ctx) => {
+		syncRlmEnv(ctx, ctx.model, { preserveExistingModel: true });
+		updateUi(ctx, depth, maxDepth);
 	});
 
-	// Update on session switch (new session resets UI)
-	pi.on("session_switch", async (_event, ctx) => {
-		const theme = ctx.ui.theme;
-		const label = theme.fg("accent", "ypi");
-		const depthInfo = theme.fg("dim", ` ∞ depth ${depth}/${maxDepth}`);
-		ctx.ui.setStatus("ypi", label + depthInfo);
-		ctx.ui.setTitle("ypi");
+	pi.on("model_select", (event: ModelSelectEvent, ctx) => {
+		syncRlmEnv(ctx, event.model);
 	});
 }


### PR DESCRIPTION
## Bug
When starting a session in ypi with ChatGPT model, hitting a limit, and switching to another model, rlm_query still uses the ChatGPT model. Expected: rlm_query should use the newly selected model, same as the parent.

## Fix
This change ensures that when a user switches models interactively, the RLM_PROVIDER and RLM_MODEL environment variables are properly synchronized into child calls.

Key improvements:
- Extracted syncRlmEnv and updateUi helper functions for better code organization
- Added model_select event handler to update environment when user changes models
- Preserved existing model state on session_start with preserveExistingModel option
- Ensures bash tool executions inherit correct model information

## Testing
Verified by:
1. Starting ypi session with one model
2. Switching to a different model interactively
3. Confirming rlm_query uses the new model for sub-calls