### PR TITLE
fix: make depth meter meaningful with dynamic rlm_query call counter

### DIFF
--- a/extensions/ypi.ts
+++ b/extensions/ypi.ts
@@ -12,28 +12,57 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
+interface StatusCtx {
+	ui: {
+		theme: { fg: (kind: string, text: string) => string };
+		setStatus: (key: string, value: string) => void;
+		setTitle: (title: string) => void;
+	};
+}
+
 export default function (pi: ExtensionAPI) {
-	const depth = parseInt(process.env.RLM_DEPTH || "0", 10);
-	const maxDepth = parseInt(process.env.RLM_MAX_DEPTH || "3", 10);
+	// Track recursive calls made from this process
+	let rlmCalls = 0;
 
-	pi.on("session_start", async (_event, ctx) => {
+	function getDepth(): number {
+		return parseInt(process.env.RLM_DEPTH || "0", 10);
+	}
+
+	function getMaxDepth(): number {
+		return parseInt(process.env.RLM_MAX_DEPTH || "3", 10);
+	}
+
+	function updateStatus(ctx: StatusCtx) {
 		const theme = ctx.ui.theme;
-
-		// Footer status: ypi with depth info
+		const depth = getDepth();
+		const maxDepth = getMaxDepth();
 		const label = theme.fg("accent", "ypi");
-		const depthInfo = theme.fg("dim", ` ∞ depth ${depth}/${maxDepth}`);
-		ctx.ui.setStatus("ypi", label + depthInfo);
 
-		// Terminal tab/window title
-		ctx.ui.setTitle("ypi");
+		let suffix: string;
+		if (rlmCalls > 0) {
+			const callStr = rlmCalls === 1 ? "1 call" : `${rlmCalls} calls`;
+			suffix = ` ∞ d${depth}/${maxDepth} · ${callStr}`;
+		} else {
+			suffix = ` ∞ d${depth}/${maxDepth}`;
+		}
+
+		ctx.ui.setStatus("ypi", label + theme.fg("dim", suffix));
+		ctx.ui.setTitle(`ypi d${depth}`);
+	}
+
+	// Detect rlm_query invocations from bash tool results
+	pi.on("tool_result", async (event, _ctx) => {
+		if (event.isError) return;
+		if (event.toolName !== "bash") return;
+
+		const input = event.input as Record<string, unknown> | undefined;
+		const command = typeof input?.command === "string" ? input.command : "";
+		if (/\brlm_query\b/.test(command)) {
+			rlmCalls++;
+		}
 	});
 
-	// Update on session switch (new session resets UI)
-	pi.on("session_switch", async (_event, ctx) => {
-		const theme = ctx.ui.theme;
-		const label = theme.fg("accent", "ypi");
-		const depthInfo = theme.fg("dim", ` ∞ depth ${depth}/${maxDepth}`);
-		ctx.ui.setStatus("ypi", label + depthInfo);
-		ctx.ui.setTitle("ypi");
-	});
+	pi.on("session_start", async (_event, ctx) => updateStatus(ctx));
+	pi.on("session_switch", async (_event, ctx) => updateStatus(ctx));
+	pi.on("turn_end", async (_event, ctx) => updateStatus(ctx));
 }


### PR DESCRIPTION
## Problem

The depth meter showed `∞ depth 0/3` at all times during interactive use. Since children run headless (`pi -p`), the user never sees depth > 0. The status bar was effectively a static label.

## Fix

1. **Read RLM_DEPTH dynamically** — replaced module-level constants with `getDepth()`/`getMaxDepth()` that re-read `process.env` on every update
2. **Track rlm_query calls** — hooked into `tool_result` to detect bash commands containing `rlm_query` and increment a counter
3. **Show call counter in status** — the bar now shows `ypi  ∞ d0/3 · 3 calls` so the human gets visual feedback that recursion is happening
4. **Refresh on turn_end** — status bar updates after every agent turn (previously only on session start/switch)
5. **Depth in terminal title** — `ypi d0` instead of just `ypi`

## Behavior

```
ypi  ∞ d0/3              ← fresh session
ypi  ∞ d0/3 · 1 call     ← after first rlm_query returns
ypi  ∞ d0/3 · 3 calls    ← after three recursive calls
```

If ypi is ever run at depth > 0 with a visible TUI, the depth number updates accordingly — but the main interaction is the call counter ticking up as `rlm_query` calls complete.